### PR TITLE
Fix config name so the package works

### DIFF
--- a/lib/theme-switcher.coffee
+++ b/lib/theme-switcher.coffee
@@ -25,11 +25,11 @@ module.exports =
     currentUITheme     = currentThemes[0]
     currentSyntaxTheme = currentThemes[1]
 
-    uiThemeOne = atom.config.get('atom-theme-switcher.uiThemeOne')
-    uiThemeTwo = atom.config.get('atom-theme-switcher.uiThemeTwo')
+    uiThemeOne = atom.config.get('theme-switcher.uiThemeOne')
+    uiThemeTwo = atom.config.get('theme-switcher.uiThemeTwo')
 
-    syntaxThemeOne = atom.config.get('atom-theme-switcher.syntaxThemeOne')
-    syntaxThemeTwo = atom.config.get('atom-theme-switcher.syntaxThemeTwo')
+    syntaxThemeOne = atom.config.get('theme-switcher.syntaxThemeOne')
+    syntaxThemeTwo = atom.config.get('theme-switcher.syntaxThemeTwo')
 
     if currentUITheme == uiThemeOne
       currentThemes[0] = uiThemeTwo

--- a/spec/theme-switcher-spec.coffee
+++ b/spec/theme-switcher-spec.coffee
@@ -28,15 +28,15 @@ describe 'ThemeSwitcher', ->
         expect(syntaxThemeAfterTrigger).not.toEqual(defaultSyntaxTheme)
 
         expect(uiThemeAfterTrigger)
-          .toEqual(atom.config.get('atom-theme-switcher.uiThemeOne'))
+          .toEqual(atom.config.get('theme-switcher.uiThemeOne'))
 
         expect(syntaxThemeAfterTrigger)
-          .toEqual(atom.config.get('atom-theme-switcher.syntaxThemeOne'))
+          .toEqual(atom.config.get('theme-switcher.syntaxThemeOne'))
 
         atom.commands.dispatch workspaceElement, 'theme-switcher:switch'
 
         expect(atom.config.get('core.themes')[0])
-          .toEqual(atom.config.get('atom-theme-switcher.uiThemeTwo'))
+          .toEqual(atom.config.get('theme-switcher.uiThemeTwo'))
 
         expect(atom.config.get('core.themes')[1])
-          .toEqual(atom.config.get('atom-theme-switcher.syntaxThemeTwo'))
+          .toEqual(atom.config.get('theme-switcher.syntaxThemeTwo'))


### PR DESCRIPTION
This appears to be an issue with a discrepancy between the local name (atom-theme-switcher) and the name when downloaded from apm (theme-switcher). The tests pass but I don't think they are actually checking anything. Might be good to change the name of the repo to match the apm name.